### PR TITLE
po: Add French translation

### DIFF
--- a/po/fr/plasma_applet_org.kde.workraveApplet.po
+++ b/po/fr/plasma_applet_org.kde.workraveApplet.po
@@ -1,0 +1,183 @@
+# Copyright (C) 2020 This file is copyright:
+# This file is distributed under the same license as the Workrave Plasma applet package.
+#
+# Johnny Jazeix <jazeix@gmail.com>, 2020.
+msgid ""
+msgstr ""
+"Project-Id-Version: Workrave Plasma applet\n"
+"Report-Msgid-Bugs-To: https://github.com/wojnilowicz/workrave-applet/issues\n"
+"POT-Creation-Date: 2020-05-15 12:20+0200\n"
+"PO-Revision-Date: 2020-07-05 21:32+0200\n"
+"Last-Translator: Johnny Jazeix <jazeix@gmail.com>\n"
+"Language-Team: French <kde-francophone@kde.org>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Lokalize 20.04.2\n"
+
+#: src/contents/config/config.qml:6
+#, kde-format
+msgid "Timers"
+msgstr "Minuteurs"
+
+#: src/contents/config/config.qml:12
+#, kde-format
+msgid "Appearance"
+msgstr "Apparence"
+
+#: src/contents/ui/config/ConfigAppearance.qml:30
+#, kde-format
+msgid "Display progress bar"
+msgstr "Afficher la barre de progression"
+
+#: src/contents/ui/config/ConfigAppearance.qml:43
+#, kde-format
+msgid "Background in normal state"
+msgstr "Arrière-plan en état normal"
+
+#: src/contents/ui/config/ConfigAppearance.qml:48
+#, kde-format
+msgid "Background in overdue state"
+msgstr "Arrière-plan quand le temps est dépassé"
+
+#: src/contents/ui/config/ConfigAppearance.qml:53
+#, kde-format
+msgid "Foreground in activity state"
+msgstr "Avant-plan en état d'activité"
+
+#: src/contents/ui/config/ConfigAppearance.qml:58
+#, kde-format
+msgid "Foreground at idle time in elapsed time"
+msgstr "Avant-plan pendant le temps d'inactivité par rapport au temps déjà effectué"
+
+#: src/contents/ui/config/ConfigAppearance.qml:63
+#, kde-format
+msgid "Foreground at idle time"
+msgstr "Avant-plan dans le temps d'inactivité"
+
+#: src/contents/ui/config/ConfigAppearance.qml:69
+#: src/contents/ui/config/ConfigAppearance.qml:153
+#, kde-format
+msgid "Height multiplier"
+msgstr "Multiplicateur de taille"
+
+#: src/contents/ui/config/ConfigAppearance.qml:87
+#, kde-format
+msgid "Display label"
+msgstr "Afficher le nom"
+
+#: src/contents/ui/config/ConfigAppearance.qml:102
+#, kde-format
+msgid "Use custom font"
+msgstr "Utiliser une police personnalisée"
+
+#: src/contents/ui/config/ConfigAppearance.qml:117
+#, kde-format
+msgid "Custom font..."
+msgstr "Police personnalisée…"
+
+#: src/contents/ui/config/ConfigAppearance.qml:131
+#, kde-format
+msgid "Reset custom font to theme default."
+msgstr "Réinitialiser la police à la valeur du thème par défaut."
+
+#: src/contents/ui/config/ConfigAppearance.qml:148
+#, kde-format
+msgid "Color"
+msgstr "Couleur"
+
+#: src/contents/ui/config/ConfigAppearance.qml:164
+#, kde-format
+msgid "Misc"
+msgstr "Divers"
+
+#: src/contents/ui/config/ConfigAppearance.qml:174
+#, kde-format
+msgid "Extra width per timer"
+msgstr "Largeur additionnelle entre minuteurs"
+
+#: src/contents/ui/config/ConfigAppearance.qml:183
+#, kde-format
+msgid "Spacing between timers"
+msgstr "Espacement entre minuteurs"
+
+#: src/contents/ui/config/ConfigAppearance.qml:192
+#, kde-format
+msgid "Use Workrave colors"
+msgstr "Utiliser les couleurs de Workrave"
+
+#: src/contents/ui/config/ConfigAppearance.qml:204
+#, kde-format
+msgid "Use system theme colors"
+msgstr "Utiliser les couleurs du thème du système"
+
+#: src/contents/ui/config/ConfigTimers.qml:17
+#, kde-format
+msgid "Enable micro break timer"
+msgstr "Activer les minuteurs pour les petites pauses"
+
+#: src/contents/ui/config/ConfigTimers.qml:22
+#, kde-format
+msgid "Enable rest timer"
+msgstr "Activer les minuteurs de repos"
+
+#: src/contents/ui/config/ConfigTimers.qml:27
+#, kde-format
+msgid "Enable daily limit timer"
+msgstr "Activer les minuteurs de limite d'utilisation quotidienne"
+
+#: src/contents/ui/config/ConfigTimers.qml:32
+#, kde-format
+msgid "Detect Workrave configuration changes"
+msgstr "Détecter les changements de configuration de Workrave"
+
+#: src/contents/ui/config/ConfigTimers.qml:34
+#, kde-format
+msgid ""
+"Disable if performance is of concern, and you want to update it manually in "
+"context menu."
+msgstr "Désactiver si vous voulez mettre à jour les minuteurs manuellement à partir du menu contextuel de l'applet (plutôt qu'à chaque changement dans Workrave)."
+
+#: src/contents/ui/config/ConfigTimers.qml:41
+#, kde-format
+msgid "Update interval in seconds"
+msgstr "Mettre à jour l'intervalle en secondes"
+
+#: src/contents/ui/config/ConfigTimers.qml:44
+#, kde-format
+msgid ""
+"Set higher if performance is of concern, and you don't need frequent timer "
+"readings."
+msgstr "Désactiver si vous n'avez pas besoin que les minuteurs se rafraîchissent toutes les secondes mais à l'intervalle défini."
+
+#: src/contents/ui/main.qml:272
+#, kde-format
+msgid "Reload Workrave configuration"
+msgstr "Recharger la configuration de Workrave"
+
+#: src/contents/ui/main.qml:273
+#, kde-format
+msgid "Recalculate applet size"
+msgstr "Recalculer la taille de l'applet"
+
+#: src/contents/ui/main.qml:284
+#, kde-format
+msgid "Workrave not installed"
+msgstr "Workrave non installé"
+
+#: src/contents/ui/main.qml:285
+#, kde-format
+msgid "Please install Workrave."
+msgstr "Veuillez installer Workrave."
+
+#: src/contents/ui/main.qml:336
+#, kde-format
+msgid "No Workrave timers added"
+msgstr "Aucun minuteur Workrave ajouté"
+
+#: src/contents/ui/main.qml:337
+#, kde-format
+msgid "Please add a timer in applet settings."
+msgstr "Veuillez ajouter un minuteur dans la configuration de l'applet"


### PR DESCRIPTION
Hi,
first of all, thank you for all your work in KDE for Polish translation.

It would be nice to add a context for the 2 strings that are tooltips, I had a hard time understanding them (and I'm not 100% sure).
Just in case, to add translator comments in qml, it is "//: comment".

Here is the French translation.

Johnny